### PR TITLE
Clicking outside dialog will dimiss dialog (cancel) if configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ let options = {
     verification: 'continue', // for hard confirm, user will be prompted to type this to enable the proceed button
     verificationHelp: 'Type "[+:verification]" below to confirm', // Verification help text. [+:verification] will be matched with 'options.verification' (i.e 'Type "continue" below to confirm')
     clicksCount: 3, // for soft confirm, user will be asked to click on "proceed" btn 3 times before actually proceeding
+    clickOutsideCloses: false // set to true to close the dialog when clicking outside of the dialog window, i.e. click landing on the mask 
 };
 
 this.$dialog.confirm(message, options)

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ let options = {
     verification: 'continue', // for hard confirm, user will be prompted to type this to enable the proceed button
     verificationHelp: 'Type "[+:verification]" below to confirm', // Verification help text. [+:verification] will be matched with 'options.verification' (i.e 'Type "continue" below to confirm')
     clicksCount: 3, // for soft confirm, user will be asked to click on "proceed" btn 3 times before actually proceeding
-    clickOutsideCloses: false // set to true to close the dialog when clicking outside of the dialog window, i.e. click landing on the mask 
+    backdropClose: false // set to true to close the dialog when clicking outside of the dialog window, i.e. click landing on the mask 
 };
 
 this.$dialog.confirm(message, options)

--- a/src/docs/components/app.vue
+++ b/src/docs/components/app.vue
@@ -52,6 +52,9 @@
                     <h4>
                         <button class="button" @click="showAnimationBounceDialog()">{{ trans('content.examples.method_usage.7') }}</button>
                     </h4>
+                    <h4>
+                        <button class="button" @click="showBasicDialogCloseClickOutside()">{{ trans('content.examples.method_usage.8') }}</button>
+                    </h4>
                 </section>
 
                 <section>
@@ -171,6 +174,17 @@
                         this.$notify({type: 'success', text: trans('messages.click_cancel')})
                     })
             },
+            showBasicDialogCloseClickOutside(){
+                this.$dialog.confirm(trans('messages.basic'), {
+                    clickOutsideCloses: true
+                }).then(() => {
+                        this.$notify({type: 'success', text: trans('messages.click_continue')})
+                    })
+                    .catch(() => {
+                        this.$notify({type: 'success', text: trans('messages.click_cancel')})
+                    })
+            },
+
             showSoftConfirmDialog(){
                 this.$dialog.confirm(trans('messages.soft'), {type: 'soft'})
                     .then(() => {

--- a/src/docs/components/app.vue
+++ b/src/docs/components/app.vue
@@ -176,7 +176,7 @@
             },
             showBasicDialogCloseClickOutside(){
                 this.$dialog.confirm(trans('messages.basic'), {
-                    clickOutsideCloses: true
+                    backdropClose: true
                 }).then(() => {
                         this.$notify({type: 'success', text: trans('messages.click_continue')})
                     })

--- a/src/docs/js/translations/en.js
+++ b/src/docs/js/translations/en.js
@@ -32,7 +32,8 @@ export default {
                 4: "Loading Dialog - Useful with ajax",
                 5: "Reversed Dialog - switch buttons",
                 6: "Fade Dialog - Animation",
-                7: "Bounce Dialog - Animation"
+                7: "Bounce Dialog - Animation",
+                8: 'Close when clicking outside dialog'
             },
             directive_usage: {
                 1: "Give it a string",

--- a/src/plugin/components/dialog-window.vue
+++ b/src/plugin/components/dialog-window.vue
@@ -127,7 +127,7 @@
         },
         methods: {
             closeAtOutsideClick() {
-              if (this.options.clickOutsideCloses === true) {
+              if (this.options.backdropClose === true) {
                   this.cancel()
               }
             },

--- a/src/plugin/components/dialog-window.vue
+++ b/src/plugin/components/dialog-window.vue
@@ -1,13 +1,14 @@
 <template>
     <div>
         <transition name="dg-backdrop" appear @after-leave="animationEnded('backdrop')">
-            <div v-if="show" class="dg-backdrop"></div>
+            <div v-if="show" class="dg-backdrop" >
+            </div>
         </transition>
 
         <transition :name="animation" @after-leave="animationEnded('content')" appear>
-            <div v-if="show" :class="['dg-container', {'dg-container--has-input': (isHardConfirm || isPrompt)}]">
+            <div v-if="show" :class="['dg-container', {'dg-container--has-input': (isHardConfirm || isPrompt)}]" @click="closeAtOutsideClick" >
                 <div class="dg-content-cont dg-content-cont--floating">
-                    <div class="dg-main-content">
+                    <div class="dg-main-content" @click.stop>
 
                         <div :class="['dg-content-body', {'dg-content-body--has-title': messageHasTitle}]">
                             <template v-if="messageHasTitle">
@@ -125,6 +126,11 @@
             this.isHardConfirm && this.$refs.inputElem.focus()
         },
         methods: {
+            closeAtOutsideClick() {
+              if (this.options.clickOutsideCloses === true) {
+                  this.cancel()
+              }
+            },
             clickRightBtn(){
                 this.options.reverse ? this.cancel() : this.proceed()
             },


### PR DESCRIPTION
Clicking outside dialog main area closes the dialog, if configured. Updated examples and README.md

Add the option clickOutsideCloses: true to your options when initialising the dialog. Any clicks outside the dialog will dismiss the dialog. 

`this.$dialog.confirm(trans('messages.basic'), {
                    clickOutsideCloses: true
                })`

**Technical change**: Click listener on the container div that closes (if configured) and a stopping propagation of clicks originating from the main-content area to prevent clicks within the main area to accidentally dismiss the dialog.