### PR TITLE
add defaultdata to submitDialogForm

### DIFF
--- a/src/plugin/js/mixins/dialog-mixin.js
+++ b/src/plugin/js/mixins/dialog-mixin.js
@@ -63,7 +63,7 @@ export default {
 			this.options.reverse ? this.proceed(this.getDefaultData()) : this.cancel()
 		},
 		submitDialogForm () {
-			this.okBtnDisabled || this.proceed()
+			this.okBtnDisabled || this.proceed(this.getDefaultData())
 		},
 		getDefaultData () {
 			return this.isPrompt ? this.input : null


### PR DESCRIPTION
Adding the content of prompt even for regular form submit outside clicks
e.g. by clicking enter

The one-line change seems pretty obvious. I couldn't get the tests running on my machine otherwise I would have added a test.

Solves this bug: https://github.com/Godofbrowser/vuejs-dialog/issues/52