### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ this.$dialog
   .prompt({
     title: "Let's hear from you",
     body: "What is the most important thing in life?",
+  }, {
     promptHelp: 'Type in the box below and click "[+:okText]"'
   })
   .then(dialog => {


### PR DESCRIPTION
Fixed 'promptHelp' option being in message

This PR will update README.md to correct the usage of 'promptHelp' to set a custom promptHelpText.
On the current README it is incorrectly within the message option while it has to be inside the options object (arg 2)