### PR TITLE
Being able to pass router to new adhoc Vue instance

### DIFF
--- a/src/plugin/js/constants.js
+++ b/src/plugin/js/constants.js
@@ -42,5 +42,6 @@ export const DEFAULT_OPTIONS = {
 	customClass          : '',
 	verification         : 'continue',
 	verificationHelp     : 'Type "[+:verification]" below to confirm',
-	promptHelp      	 : 'Type in the box below and click "[+:okText]"'
+	promptHelp      	 : 'Type in the box below and click "[+:okText]"',
+	forwardPlugin		 : {}
 }

--- a/src/plugin/js/index.js
+++ b/src/plugin/js/index.js
@@ -26,7 +26,7 @@ Plugin.prototype.mountIfNotMounted = function () {
 		let node = document.createElement('div')
 		document.querySelector('body').appendChild(node)
 
-		let Vm = new DialogConstructor()
+		let Vm = new DialogConstructor(this.globalOptions.forwardPlugin)
 
 		Vm.registeredViews = this.registeredComponents()
 


### PR DESCRIPTION
While using component in vuejs-dialog, the component may rely on router.
Unfortunately as the vuejs-dialog is creating a new dedicated Vue root, the existing plugin are not passed...

This solution, allow to pass any plugin to vuejs-dialog new root...

caller code sample
```
Vue.use(VuejsDialog, { forwardPlugin: { router } } );
```